### PR TITLE
Improve LR parser robustness

### DIFF
--- a/Main.java
+++ b/Main.java
@@ -1,318 +1,402 @@
-import java.util.Stack;
-import java.util.Hashtable;
-import java.util.Enumeration;
-import java.util.Scanner;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.Stack;
 
 public class Main {
-	public static void main(String[] args) throws FileNotFoundException {
-		// use the following statement if your input file is in src folder
-		// File fp = new File(System.getProperty("user.dir") + "\\src\\" + "rules");
-		// use the following one if your input file is under the project
-		File fp = new File("rules");
-    	Scanner sc = new Scanner(fp);    	
-    	String rules = "";
-    	while(sc.hasNextLine()) {
-    		rules += sc.nextLine() + "\n";
-    	}
-    	String[] rulesCollections = rules.split("\n");
-    	// create S'->S
-    	String r0 = rulesCollections[0].charAt(0) + "'->" + rulesCollections[0].charAt(0);
-    	System.out.println("r0: " + r0);
-    	for(int i = 0; i < rulesCollections.length; i++) {
-    		System.out.println("r" + (i + 1) + ": " + rulesCollections[i]);
-    	}
-    	String nonTerminals = findNonTerminals(rulesCollections);
-    	System.out.println("NonTerminals: " + nonTerminals);
-    	String terminals = findTerminals(rulesCollections);
-    	System.out.println("Terminals: " + terminals);
-    	
-    	// generate the augmented rule S'->.S
-    	String I0 = r0.substring(0, r0.indexOf("->") + 2) + "." + r0.substring(r0.indexOf("->") + 2);
-    	
-	    I0 = Closure(I0, nonTerminals, rulesCollections);
-	    
-	    Hashtable <Integer, String> states = new Hashtable <Integer, String> ();
-	    states.put(0, I0);
-	    String Gotos = constructStateDiagram(states, nonTerminals, rulesCollections);
-	    displayStates(states);
-	    
-	    System.out.println("Gotos: " + Gotos);
-	    Hashtable <String, String> parsingTable = parsingTable(states, Gotos, terminals, nonTerminals, rulesCollections);
-	    
-	    displayParsingTable(states, parsingTable, terminals, nonTerminals);
-	    
-	    String input = "aabb";
-	    parsing(parsingTable, input, rulesCollections);
-	    
-    	sc.close();
+
+    private static class Production {
+        private final String LHS;
+        private final String RHS;
+
+        Production(String lhs, String rhs) {
+            this.LHS = lhs;
+            this.RHS = rhs;
+        }
+
+        String getLHS() {
+            return LHS;
+        }
+
+        String getRHS() {
+            return RHS;
+        }
+
+        String toRuleString() {
+            return LHS + "->" + RHS;
+        }
+
+        static Production fromRule(String rule) {
+            int idx = rule.indexOf("->");
+            String lhs = rule.substring(0, idx);
+            String rhs = rule.substring(idx + 2);
+            return new Production(lhs, rhs);
+        }
     }
-	
-	public static String findNonTerminals(String[] rulesCollections) {
-		String nonTerminals = "";
-		char sep = ',';
-		for(int i = 0; i < rulesCollections.length; i++) {
-			char symbol = rulesCollections[i].charAt(0);
-			// add the new symbol into nonTerminals 
-			if(nonTerminals.indexOf(symbol) == -1) {
-				nonTerminals += Character.toString(symbol) + sep;
-			}
-		}
-		return nonTerminals.substring(0, nonTerminals.length() - 1);
-	}
-	
-	public static String findTerminals(String[] rulesCollections) {
-		String terminals = "";
-		String nonTerminals = findNonTerminals(rulesCollections);
-		char sep = ',';
-		for(int i = 0; i < rulesCollections.length; i++) {
-			String rhs = rulesCollections[i].substring(rulesCollections[i].indexOf("->") + 2);
-			for(int j = 0; j < rhs.length(); j++) {
-				char symbol = rhs.charAt(j);
-				// add the new symbol into terminals when it's not a nonTerminal
-				if(terminals.indexOf(symbol) == -1 && nonTerminals.indexOf(symbol) == -1) {
-					terminals += Character.toString(symbol) + sep;
-				}
-			}
-		}
-		return terminals.substring(0, terminals.length() - 1);
-	}
-	
-	public static String Closure (String state, String nonTerminals, String[] rulesCollections) {
-		// boolean array used to identify if the symbol has been added
-		boolean[] tags = new boolean[(nonTerminals.length() + 1) / 2];
-		for(int i = 0; i < tags.length; i++)
-			tags[i] = false;
-		for(int i = 0; i < tags.length; i++) {
-			String[] items = state.split(",");
-			for(int j = 0; j < items.length; j++) {
-				// fetch the symbol after dot 
-				if(items[j].indexOf(".") + 1 == items[j].length()) {
-					return state;
-				}else {
-					char symbol = items[j].charAt(items[j].indexOf(".") + 1);
-					// if the symbol is a nonTerminal and not added so far
-					if(nonTerminals.indexOf(symbol) != -1) {
-						int k = (nonTerminals.indexOf(symbol) + 1) / 2;
-						if(tags[k]) continue;
-						// look for rules that begin with the symbol
-						for(int l = 0; l < rulesCollections.length; l++) {
-							char lhs = rulesCollections[l].charAt(0);
-							if(lhs == symbol) {
-								// add rules into the state with dot on rhs
-								int idx = rulesCollections[l].indexOf("->");
-								state += "," + rulesCollections[l].substring(0, idx + 2) + "." + rulesCollections[l].substring(idx + 2);
-							}						
-						}				
-						// mark the symbol as added
-						tags[k] = true;
-					}
-				}
-			}			
-		}
-		return state;
-	}	
-	
-	public static String Goto (String state, char symbol, String nonTerminals, String[] rulesCollections) {
-		String[] items = state.split(",");
-		String newState = "", toUpdate = "";
-		for(int i = 0; i < items.length; i++) {
-			// find all items that need to be updated
-			String rhs = items[i].substring(items[i].indexOf("->") + 2);
-			if(rhs.indexOf("." + symbol) != -1) {
-				toUpdate += items[i] + ",";
-			}
-		}
-		if(toUpdate.equals("")) {
-			return "";
-		}else {
-			// get rid of the comma at the end of line
-			toUpdate = toUpdate.substring(0, toUpdate.length() - 1);
-			// split the items that need to be updated into s
-			String[] s = toUpdate.split(",");
-			for(int i = 0; i < s.length; i++) {
-				// shift the dot one digit to its right
-				if(s[i].indexOf(".") + 2 == s[i].length()) {
-					newState += s[i].substring(0, s[i].indexOf(".")) + symbol + ".";
-				}else {
-					newState += s[i].substring(0, s[i].indexOf(".")) + symbol + "." + s[i].substring(s[i].indexOf(symbol, s[i].indexOf(".")) + 1);	
-				}
-			}		
-			return Closure(newState, nonTerminals, rulesCollections);
-		}
-	}
-	
-	public static String constructStateDiagram(Hashtable <Integer, String> states, String nonTerminals, String[] rulesCollections){
-		String Gotos = "";
-	    int n = 1, stateSize = states.size(), gotoSize = Gotos.split(",").length;
-	    while(true) {
-	    	for(int i = 0; i < states.size(); i++) {
-	    		// for every item in each state
-	    		for(int j = 0; j < states.get(i).split(",").length; j++) {
-	    			String item = states.get(i).split(",")[j];
-	    			if(item.indexOf(".") + 1 == item.length()) {
-	    				continue;
-	    			} else {
-		    			char symbol = item.charAt(item.indexOf(".") + 1);
-		    			// check which state the current item is going to
-		    			String dest = Goto(item, symbol, nonTerminals, rulesCollections);
-		    			if(!states.contains(dest)) {
-		    				states.put(n++, dest);
-		    				Gotos += i + "" + symbol + "" + findKey(states, dest) + ",";		    				
-		    			} else {
-		    				String str = i + "" + symbol + "" + findKey(states, dest) + ",";
-		    				if(Gotos.indexOf(str) == -1) {
-		    					Gotos += str;
-		    				}
-		    			}
-	    			}
-	    		}
-	    	}	    	
-	    	// if there is no change made into either state or goto, terminate the loop
-	    	if (stateSize != states.size() || gotoSize != Gotos.split(",").length) {
-	    		stateSize = states.size();
-	    		gotoSize = Gotos.split(",").length;
-	    	} else {
-	    		break;
-	    	}
-	    }
-	    // get rid of the final comma
-	    return Gotos.substring(0, Gotos.length() - 1);
-	}
-	
-	public static Hashtable <String, String> parsingTable(Hashtable <Integer, String> states, String Gotos, String terminals, String nonTerminals, String[] rulesCollections){
-		// Gotos: 0S1,0A2,0a3,0b4,2A5,2a3,2b4,3A6,3a3,3b4
-		Hashtable <String, String> pT = new Hashtable <String, String>();
-		String[] actions = Gotos.split(",");
-		// adding shift actions
-		for(int i = 0; i < actions.length; i++) {
-			char symbol = actions[i].charAt(1);
-			if(terminals.indexOf(symbol) != -1) {
-				pT.put(actions[i].substring(0,2), "s" + actions[i].charAt(2));
-			} else if (nonTerminals.indexOf(symbol) != -1) {
-				pT.put(actions[i].substring(0,2), "" + actions[i].charAt(2));
-			}
-		}
-		// adding reduce actions
-		String I0 = rulesCollections[0].charAt(0) + "'->" + rulesCollections[0].charAt(0) + ".";
-		// add <"1$", "accept">
-		for(int i = 0; i < states.size(); i++){
-			if(states.get(i).indexOf(I0) != -1) {
-				pT.put(i + "$", "accept");
-				break;
-			} 
-		}
-		for(int i = 0; i < states.size(); i++) {
-			for(int j = 0; j < rulesCollections.length; j++) {
-				if(states.get(i).indexOf(rulesCollections[j] + ".") != -1) {
-					// i: state number, j: rule number
-					for(int k = 0; k < terminals.split(",").length; k++) {
-						pT.put(i + "" + terminals.split(",")[k], "r" + (j + 1));
-					}
-					// add i$rj
-					pT.put(i + "$", "r" + (j + 1));
-				}
-			}
-		}
-		return pT;
-	}	
-	
-	public static int findKey(Hashtable<Integer, String> states, String value) {
-		Enumeration <Integer> keys = states.keys();
-		while(keys.hasMoreElements()) {
-			int key = keys.nextElement();
-			if(states.get(key).equals(value)) {
-				return key;
-			}
-		}
-		return -1;
-	}
-	
-	public static void displayStates(Hashtable <Integer, String> states) {
-    	for(int i = 0; i < states.size(); i++) {
-    		System.out.println("I" + i + ": " + states.get(i));
-    	}
-	}
-	
-	public static void displayParsingTable(Hashtable <Integer, String> states, Hashtable <String, String> pT, String terminals, String nonTerminals) {
-		// display the first two rows
-		// 1: action & goto
-		System.out.printf("The parsing table:\n%24s%18s\n", "action", "goto");
-		// 2. state terminals $ nonTerminals
-		System.out.print("state");
-		String firstRow  = terminals.replace(",", "") + "$" + nonTerminals.replace(",", "");
-		for(int i = 0; i < firstRow.substring(0, firstRow.indexOf("$")).length(); i++) {
-			System.out.printf("%8c", firstRow.charAt(i));
-		}
-		System.out.printf("%9c", '$');
-		for(int i = firstRow.indexOf("$") + 1; i < firstRow.length(); i++) {
-			System.out.printf("%8c", firstRow.charAt(i));
-		}
-		System.out.println();
-		// state and corresponding actions
-		for(int i = 0; i < states.size(); i++) {
-			System.out.printf("%-6d", i);
-			for(int j = 0; j < firstRow.length(); j++) {
-				String result = pT.get(i + "" + firstRow.charAt(j));
-				if(result == null) {
-					System.out.printf("%8c", ' ');
-				}else {
-					System.out.printf("%8s", result);
-				}			
-			}
-			System.out.println();
-		}
-		System.out.println();
-	}
-	
-	public static void parsing(Hashtable<String, String> pT, String input, String[] rulesCollections) {
-		Stack <String> s = new Stack <String> ();
-		s.push("0");
-		input += "$";
-		System.out.printf("Input: %s\n", input);
-		System.out.printf("%-12s%8s%14s\n", "stack", "input", "action");
-		String action = "";
-		while (true) {
-			String st = s.toString().replaceAll(",| ", "");
-			System.out.printf("%-12s", st.substring(1, st.length() - 1));
-			System.out.printf("%8s", input);
-			if(s.size() == 1) {
-				action = pT.get(s.peek() + input.charAt(0));	
-			} else {
-				action = pT.get(s.peek().charAt(1) + "" + input.charAt(0));
-			}
-			if (action == null) {
-				// no available action -> syntax error
-				System.out.printf("%14s\n", "error");
-				break;
-			} else {
-				System.out.printf("%14s\n", action);
-				if (action.equals("accept")) {
-					// successfully parsed
-					break;
-				} else if (action.charAt(0) == 's') {
-					// shift
-					s.push(input.charAt(0) + "" + action.charAt(1));
-					input = input.substring(1);				
-				} else if (action.charAt(0) == 'r') {
-					// reduce				
-					int idx = action.charAt(1) - 49;
-					String lhs = rulesCollections[idx].substring(0, 1);
-					String rhs = rulesCollections[idx].substring(rulesCollections[idx].indexOf("->") + 2);
-					String stackContent = s.pop().charAt(0) + "";
-					while(!stackContent.equals(rhs)){
-						stackContent = s.pop().charAt(0) + stackContent;
-					}
-					char snum = ' ';
-					if(s.size() == 1) {
-						snum = s.peek().charAt(0);
-					}else {
-						snum = s.peek().charAt(1);
-					}
-					s.push(lhs + pT.get(snum + lhs));
-				}
-			}		
-		}
-	}
+
+    public static void main(String[] args) throws FileNotFoundException {
+        File fp = new File("rules");
+        List<Production> productions = loadProductions(fp);
+        if (productions.isEmpty()) {
+            System.out.println("No grammar rules found.");
+            return;
+        }
+
+        String[] rulesCollections = new String[productions.size()];
+        for (int i = 0; i < productions.size(); i++) {
+            rulesCollections[i] = productions.get(i).toRuleString();
+        }
+
+        String augmentedRule = productions.get(0).getLHS() + "'->" + productions.get(0).getLHS();
+        System.out.println("r0: " + augmentedRule);
+        for (int i = 0; i < productions.size(); i++) {
+            System.out.println("r" + (i + 1) + ": " + productions.get(i).toRuleString());
+        }
+
+        String nonTerminals = findNonTerminals(productions);
+        System.out.println("NonTerminals: " + nonTerminals);
+        String terminals = findTerminals(productions, nonTerminals);
+        System.out.println("Terminals: " + terminals);
+
+        String I0 = augmentedRule.substring(0, augmentedRule.indexOf("->") + 2) + "." + augmentedRule.substring(augmentedRule.indexOf("->") + 2);
+        I0 = Closure(I0, nonTerminals, rulesCollections);
+
+        Hashtable<Integer, String> states = new Hashtable<>();
+        states.put(0, I0);
+        String gotos = constructStateDiagram(states, nonTerminals, rulesCollections);
+        displayStates(states);
+
+        System.out.println("Gotos: " + gotos);
+        Hashtable<String, String> parsingTable = parsingTable(states, gotos, terminals, nonTerminals, rulesCollections, productions.get(0));
+
+        displayParsingTable(states, parsingTable, terminals, nonTerminals);
+
+        String input = "aabb";
+        parsing(parsingTable, input, productions);
+    }
+
+    private static List<Production> loadProductions(File file) throws FileNotFoundException {
+        List<Production> productions = new ArrayList<>();
+        try (Scanner sc = new Scanner(file)) {
+            while (sc.hasNextLine()) {
+                String line = sc.nextLine().trim();
+                if (!line.isEmpty()) {
+                    productions.add(Production.fromRule(line));
+                }
+            }
+        }
+        return productions;
+    }
+
+    public static String findNonTerminals(List<Production> productions) {
+        Set<Character> symbols = new LinkedHashSet<>();
+        for (Production production : productions) {
+            if (!production.getLHS().isEmpty()) {
+                symbols.add(production.getLHS().charAt(0));
+            }
+        }
+        return joinCharacters(symbols);
+    }
+
+    public static String findTerminals(List<Production> productions, String nonTerminals) {
+        Set<Character> nonTerminalSet = toCharacterSet(nonTerminals);
+        Set<Character> terminals = new LinkedHashSet<>();
+        for (Production production : productions) {
+            String rhs = production.getRHS();
+            for (int i = 0; i < rhs.length(); i++) {
+                char symbol = rhs.charAt(i);
+                if (!nonTerminalSet.contains(symbol)) {
+                    terminals.add(symbol);
+                }
+            }
+        }
+        return joinCharacters(terminals);
+    }
+
+    private static String joinCharacters(Iterable<Character> characters) {
+        StringBuilder builder = new StringBuilder();
+        boolean first = true;
+        for (char ch : characters) {
+            if (!first) {
+                builder.append(',');
+            }
+            builder.append(ch);
+            first = false;
+        }
+        return builder.toString();
+    }
+
+    private static Set<Character> toCharacterSet(String csv) {
+        Set<Character> characters = new LinkedHashSet<>();
+        if (csv == null || csv.isEmpty()) {
+            return characters;
+        }
+        String[] parts = csv.split(",");
+        for (String part : parts) {
+            if (!part.isEmpty()) {
+                characters.add(part.charAt(0));
+            }
+        }
+        return characters;
+    }
+
+    public static String Closure(String state, String nonTerminals, String[] rulesCollections) {
+        boolean[] tags = new boolean[(nonTerminals.length() + 1) / 2];
+        for (int i = 0; i < tags.length; i++) {
+            tags[i] = false;
+        }
+        for (int i = 0; i < tags.length; i++) {
+            String[] items = state.split(",");
+            for (String item : items) {
+                if (item.indexOf('.') + 1 == item.length()) {
+                    return state;
+                } else {
+                    char symbol = item.charAt(item.indexOf('.') + 1);
+                    if (nonTerminals.indexOf(symbol) != -1) {
+                        int k = (nonTerminals.indexOf(symbol) + 1) / 2;
+                        if (tags[k]) {
+                            continue;
+                        }
+                        for (String rule : rulesCollections) {
+                            char lhs = rule.charAt(0);
+                            if (lhs == symbol) {
+                                int idx = rule.indexOf("->");
+                                state += "," + rule.substring(0, idx + 2) + "." + rule.substring(idx + 2);
+                            }
+                        }
+                        tags[k] = true;
+                    }
+                }
+            }
+        }
+        return state;
+    }
+
+    public static String Goto(String state, char symbol, String nonTerminals, String[] rulesCollections) {
+        String[] items = state.split(",");
+        String newState = "";
+        String toUpdate = "";
+        for (String item : items) {
+            String rhs = item.substring(item.indexOf("->") + 2);
+            if (rhs.contains("." + symbol)) {
+                toUpdate += item + ",";
+            }
+        }
+        if (toUpdate.equals("")) {
+            return "";
+        }
+        toUpdate = toUpdate.substring(0, toUpdate.length() - 1);
+        String[] s = toUpdate.split(",");
+        for (String value : s) {
+            int dotIndex = value.indexOf('.');
+            if (dotIndex + 2 == value.length()) {
+                newState += value.substring(0, dotIndex) + symbol + ".";
+            } else {
+                newState += value.substring(0, dotIndex) + symbol + "." + value.substring(value.indexOf(symbol, dotIndex) + 1);
+            }
+            newState += ",";
+        }
+        newState = newState.substring(0, newState.length() - 1);
+        return Closure(newState, nonTerminals, rulesCollections);
+    }
+
+    public static String constructStateDiagram(Hashtable<Integer, String> states, String nonTerminals, String[] rulesCollections) {
+        LinkedHashSet<String> transitions = new LinkedHashSet<>();
+        int nextStateId = states.size();
+        boolean updated;
+        do {
+            updated = false;
+            int stateCount = states.size();
+            for (int i = 0; i < stateCount; i++) {
+                String state = states.get(i);
+                if (state == null || state.isEmpty()) {
+                    continue;
+                }
+                String[] items = state.split(",");
+                Set<Character> seenSymbols = new LinkedHashSet<>();
+                for (String item : items) {
+                    int dotIndex = item.indexOf('.');
+                    if (dotIndex + 1 == item.length()) {
+                        continue;
+                    }
+                    char symbol = item.charAt(dotIndex + 1);
+                    if (!seenSymbols.add(symbol)) {
+                        continue;
+                    }
+                    String dest = Goto(state, symbol, nonTerminals, rulesCollections);
+                    if (dest.isEmpty()) {
+                        continue;
+                    }
+                    int targetState = findKey(states, dest);
+                    if (targetState == -1) {
+                        states.put(nextStateId, dest);
+                        targetState = nextStateId;
+                        nextStateId++;
+                        updated = true;
+                    }
+                    String transition = i + "" + symbol + targetState;
+                    if (transitions.add(transition)) {
+                        updated = true;
+                    }
+                }
+            }
+        } while (updated);
+        return String.join(",", transitions);
+    }
+
+    public static Hashtable<String, String> parsingTable(Hashtable<Integer, String> states, String gotos, String terminals, String nonTerminals,
+            String[] rulesCollections, Production startProduction) {
+        Hashtable<String, String> pT = new Hashtable<>();
+        String[] actions = gotos.isEmpty() ? new String[0] : gotos.split(",");
+        Set<Character> terminalSet = toCharacterSet(terminals);
+        Set<Character> nonTerminalSet = toCharacterSet(nonTerminals);
+        for (String action : actions) {
+            if (action.isEmpty()) {
+                continue;
+            }
+            int index = 0;
+            while (index < action.length() && Character.isDigit(action.charAt(index))) {
+                index++;
+            }
+            String fromState = action.substring(0, index);
+            char symbol = action.charAt(index);
+            String toState = action.substring(index + 1);
+            if (terminalSet.contains(symbol)) {
+                pT.put(fromState + symbol, "s" + toState);
+            } else if (nonTerminalSet.contains(symbol)) {
+                pT.put(fromState + symbol, toState);
+            }
+        }
+
+        String acceptItem = startProduction.getLHS() + "'->" + startProduction.getLHS() + ".";
+        for (int i = 0; i < states.size(); i++) {
+            String state = states.get(i);
+            if (state != null && state.contains(acceptItem)) {
+                pT.put(i + "$", "accept");
+                break;
+            }
+        }
+
+        for (int i = 0; i < states.size(); i++) {
+            String state = states.get(i);
+            if (state == null) {
+                continue;
+            }
+            for (int j = 0; j < rulesCollections.length; j++) {
+                String rule = rulesCollections[j] + ".";
+                if (state.contains(rule)) {
+                    for (char terminal : terminalSet) {
+                        pT.put(i + "" + terminal, "r" + (j + 1));
+                    }
+                    pT.put(i + "$", "r" + (j + 1));
+                }
+            }
+        }
+        return pT;
+    }
+
+    public static int findKey(Hashtable<Integer, String> states, String value) {
+        Enumeration<Integer> keys = states.keys();
+        while (keys.hasMoreElements()) {
+            int key = keys.nextElement();
+            if (value.equals(states.get(key))) {
+                return key;
+            }
+        }
+        return -1;
+    }
+
+    public static void displayStates(Hashtable<Integer, String> states) {
+        for (int i = 0; i < states.size(); i++) {
+            System.out.println("I" + i + ": " + states.get(i));
+        }
+    }
+
+    public static void displayParsingTable(Hashtable<Integer, String> states, Hashtable<String, String> pT, String terminals, String nonTerminals) {
+        System.out.printf("The parsing table:\n%24s%18s\n", "action", "goto");
+        System.out.print("state");
+        String firstRow = terminals.replace(",", "") + "$" + nonTerminals.replace(",", "");
+        for (int i = 0; i < firstRow.substring(0, firstRow.indexOf('$')).length(); i++) {
+            System.out.printf("%8c", firstRow.charAt(i));
+        }
+        System.out.printf("%9c", '$');
+        for (int i = firstRow.indexOf('$') + 1; i < firstRow.length(); i++) {
+            System.out.printf("%8c", firstRow.charAt(i));
+        }
+        System.out.println();
+        for (int i = 0; i < states.size(); i++) {
+            System.out.printf("%-6d", i);
+            for (int j = 0; j < firstRow.length(); j++) {
+                String result = pT.get(i + "" + firstRow.charAt(j));
+                if (result == null) {
+                    System.out.printf("%8c", ' ');
+                } else {
+                    System.out.printf("%8s", result);
+                }
+            }
+            System.out.println();
+        }
+        System.out.println();
+    }
+
+    public static void parsing(Hashtable<String, String> pT, String input, List<Production> productions) {
+        Stack<String> stack = new Stack<>();
+        stack.push("0");
+        input += "$";
+        System.out.printf("Input: %s\n", input);
+        System.out.printf("%-12s%8s%14s\n", "stack", "input", "action");
+        while (true) {
+            String stackString = stack.toString().replaceAll(",| ", "");
+            System.out.printf("%-12s", stackString.substring(1, stackString.length() - 1));
+            System.out.printf("%8s", input);
+            String stateId = extractStateId(stack);
+            String action = pT.get(stateId + input.charAt(0));
+            if (action == null) {
+                System.out.printf("%14s\n", "error");
+                break;
+            }
+            System.out.printf("%14s\n", action);
+            if (action.equals("accept")) {
+                break;
+            }
+            if (action.charAt(0) == 's') {
+                String nextState = action.substring(1);
+                stack.push(input.charAt(0) + nextState);
+                input = input.substring(1);
+                continue;
+            }
+            if (action.charAt(0) == 'r') {
+                int ruleIndex = Integer.parseInt(action.substring(1)) - 1;
+                Production rule = productions.get(ruleIndex);
+                String lhs = rule.getLHS();
+                String rhs = rule.getRHS();
+                StringBuilder stackContent = new StringBuilder();
+                stackContent.append(stack.pop().charAt(0));
+                while (!stackContent.toString().equals(rhs)) {
+                    stackContent.insert(0, stack.pop().charAt(0));
+                }
+                String nextStateId = extractStateId(stack);
+                String gotoState = pT.get(nextStateId + lhs);
+                if (gotoState == null) {
+                    System.out.printf("%14s\n", "error");
+                    break;
+                }
+                stack.push(lhs + gotoState);
+            }
+        }
+    }
+
+    private static String extractStateId(Stack<String> stack) {
+        String topEntry = stack.peek();
+        if (stack.size() == 1) {
+            return topEntry;
+        }
+        return topEntry.substring(1);
+    }
 }


### PR DESCRIPTION
## Summary
- refactor grammar loading and symbol discovery to avoid empty rules and reuse parsed Production objects
- rebuild LR(0) state construction and parsing table generation to track transitions without duplicate entries
- update parser stack handling to support multi-digit states and provide clearer error handling output

## Testing
- javac Main.java
- java Main

------
https://chatgpt.com/codex/tasks/task_e_68e44ba07f10832fb728d1f495c318c2